### PR TITLE
Shotgun pellet spread

### DIFF
--- a/src/components/sidebar/index.jsx
+++ b/src/components/sidebar/index.jsx
@@ -9,6 +9,7 @@ const Sidebar = ({ children }) => {
       <div>
         <Link to="/">Home</Link>
         <Link to="/hand-to-hand">Hand To Hand</Link>
+        <Link to="/shotguns">Shotguns</Link>
       </div>
       <div>{children}</div>
     </div>

--- a/src/model/shotguns/index.js
+++ b/src/model/shotguns/index.js
@@ -22,3 +22,23 @@ export const getRandomHitLocation = (initialLocation, spread) => {
 
   return Math.floor(Math.random() * (max - min + 1)) + min;
 };
+
+export const getRandomD100Location = (initialLocation, spread) => {
+  let location = getRandomHitLocation(initialLocation, spread);
+
+  if (location < 0 || location > 99) {
+    location = getRandomD100Location(initialLocation, spread);
+  }
+
+  return location;
+};
+
+export const getRandomD1000Location = (initialLocation, spread) => {
+  let location = getRandomHitLocation(initialLocation, spread);
+
+  if (location < 0 || location > 999) {
+    location = getRandomD1000Location(initialLocation, spread);
+  }
+
+  return location;
+};

--- a/src/model/shotguns/index.js
+++ b/src/model/shotguns/index.js
@@ -16,28 +16,14 @@ export const pelletSpreadTable = Object.freeze({
   18: 100,
 });
 
-export const getRandomHitLocation = (initialLocation, spread) => {
+export const getRandomHitLocation = (initialLocation, spread, upperLimit) => {
   const min = initialLocation - spread;
   const max = initialLocation + spread;
 
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-};
+  let location = Math.floor(Math.random() * (max - min + 1)) + min;
 
-export const getRandomD100Location = (initialLocation, spread) => {
-  let location = getRandomHitLocation(initialLocation, spread);
-
-  if (location < 0 || location > 99) {
-    location = getRandomD100Location(initialLocation, spread);
-  }
-
-  return location;
-};
-
-export const getRandomD1000Location = (initialLocation, spread) => {
-  let location = getRandomHitLocation(initialLocation, spread);
-
-  if (location < 0 || location > 999) {
-    location = getRandomD1000Location(initialLocation, spread);
+  if (location < 0 || location > upperLimit) {
+    location = getRandomHitLocation(initialLocation, spread, upperLimit);
   }
 
   return location;

--- a/src/model/shotguns/index.js
+++ b/src/model/shotguns/index.js
@@ -1,0 +1,24 @@
+export const pelletSpreadTable = Object.freeze({
+  "-12": 1,
+  "-10": 2,
+  "-6": 3,
+  "-4": 4,
+  "-2": 6,
+  0: 8,
+  2: 11,
+  4: 14,
+  6: 19,
+  8: 25,
+  10: 34,
+  12: 45,
+  14: 60,
+  16: 79,
+  18: 100,
+});
+
+export const getRandomHitLocation = (initialLocation, spread) => {
+  const min = initialLocation - spread;
+  const max = initialLocation + spread;
+
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};

--- a/src/model/shotguns/shotguns.test.js
+++ b/src/model/shotguns/shotguns.test.js
@@ -4,10 +4,9 @@ test("it does not return result less than 0 on d100", () => {
   const location = 5;
   const spread = 11;
 
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 10; i++) {
     const result = getRandomHitLocation(location, spread, 99);
 
-    console.log("result > ", result);
     expect(result >= 0 && result <= 16).toBe(true);
   }
 });
@@ -16,10 +15,9 @@ test("it does not return result greater than 99 on d100", () => {
   const location = 95;
   const spread = 11;
 
-  for (let i = 0; i < 666; i++) {
+  for (let i = 0; i < 10; i++) {
     const result = getRandomHitLocation(location, spread, 99);
 
-    console.log("result > ", result);
     expect(result >= 84 && result <= 99).toBe(true);
   }
 });
@@ -28,10 +26,9 @@ test("it does not return result less than 0 on d1000", () => {
   const location = 5;
   const spread = 11;
 
-  for (let i = 0; i < 666; i++) {
+  for (let i = 0; i < 10; i++) {
     const result = getRandomHitLocation(location, spread, 999);
 
-    console.log("result > ", result);
     expect(result >= 0 && result <= 16).toBe(true);
   }
 });
@@ -40,10 +37,9 @@ test("it does not return result greater than 999 on d1000", () => {
   const location = 995;
   const spread = 11;
 
-  for (let i = 0; i < 666; i++) {
+  for (let i = 0; i < 10; i++) {
     const result = getRandomHitLocation(location, spread, 999);
 
-    console.log("result > ", result);
     expect(result >= 984 && result <= 999).toBe(true);
   }
 });

--- a/src/model/shotguns/shotguns.test.js
+++ b/src/model/shotguns/shotguns.test.js
@@ -1,27 +1,11 @@
-import {
-  getRandomHitLocation,
-  getRandomD100Location,
-  getRandomD1000Location,
-} from "./";
-
-test("it returns a number within spread of initial location", () => {
-  const location = 50;
-  const spread = 11;
-
-  for (let i = 0; i < 666; i++) {
-    const result = getRandomHitLocation(location, spread);
-
-    console.log("result > ", result);
-    expect(result >= 39 && result <= 61).toBe(true);
-  }
-});
+import { getRandomHitLocation } from "./";
 
 test("it does not return result less than 0 on d100", () => {
   const location = 5;
   const spread = 11;
 
   for (let i = 0; i < 1; i++) {
-    const result = getRandomD100Location(location, spread);
+    const result = getRandomHitLocation(location, spread, 99);
 
     console.log("result > ", result);
     expect(result >= 0 && result <= 16).toBe(true);
@@ -33,7 +17,7 @@ test("it does not return result greater than 99 on d100", () => {
   const spread = 11;
 
   for (let i = 0; i < 666; i++) {
-    const result = getRandomD100Location(location, spread);
+    const result = getRandomHitLocation(location, spread, 99);
 
     console.log("result > ", result);
     expect(result >= 84 && result <= 99).toBe(true);
@@ -45,7 +29,7 @@ test("it does not return result less than 0 on d1000", () => {
   const spread = 11;
 
   for (let i = 0; i < 666; i++) {
-    const result = getRandomD1000Location(location, spread);
+    const result = getRandomHitLocation(location, spread, 999);
 
     console.log("result > ", result);
     expect(result >= 0 && result <= 16).toBe(true);
@@ -57,7 +41,7 @@ test("it does not return result greater than 999 on d1000", () => {
   const spread = 11;
 
   for (let i = 0; i < 666; i++) {
-    const result = getRandomD1000Location(location, spread);
+    const result = getRandomHitLocation(location, spread, 999);
 
     console.log("result > ", result);
     expect(result >= 984 && result <= 999).toBe(true);

--- a/src/model/shotguns/shotguns.test.js
+++ b/src/model/shotguns/shotguns.test.js
@@ -1,0 +1,13 @@
+import { getRandomHitLocation } from "./";
+
+test("it returns a number within spread of initial location", () => {
+  const location = 50;
+  const spread = 11;
+
+  for (let i = 0; i < 666; i++) {
+    const result = getRandomHitLocation(location, spread);
+
+    console.log("result > ", result);
+    expect(result >= 39 && result <= 61).toBe(true);
+  }
+});

--- a/src/model/shotguns/shotguns.test.js
+++ b/src/model/shotguns/shotguns.test.js
@@ -1,4 +1,8 @@
-import { getRandomHitLocation } from "./";
+import {
+  getRandomHitLocation,
+  getRandomD100Location,
+  getRandomD1000Location,
+} from "./";
 
 test("it returns a number within spread of initial location", () => {
   const location = 50;
@@ -9,5 +13,53 @@ test("it returns a number within spread of initial location", () => {
 
     console.log("result > ", result);
     expect(result >= 39 && result <= 61).toBe(true);
+  }
+});
+
+test("it does not return result less than 0 on d100", () => {
+  const location = 5;
+  const spread = 11;
+
+  for (let i = 0; i < 1; i++) {
+    const result = getRandomD100Location(location, spread);
+
+    console.log("result > ", result);
+    expect(result >= 0 && result <= 16).toBe(true);
+  }
+});
+
+test("it does not return result greater than 99 on d100", () => {
+  const location = 95;
+  const spread = 11;
+
+  for (let i = 0; i < 666; i++) {
+    const result = getRandomD100Location(location, spread);
+
+    console.log("result > ", result);
+    expect(result >= 84 && result <= 99).toBe(true);
+  }
+});
+
+test("it does not return result less than 0 on d1000", () => {
+  const location = 5;
+  const spread = 11;
+
+  for (let i = 0; i < 666; i++) {
+    const result = getRandomD1000Location(location, spread);
+
+    console.log("result > ", result);
+    expect(result >= 0 && result <= 16).toBe(true);
+  }
+});
+
+test("it does not return result greater than 999 on d1000", () => {
+  const location = 995;
+  const spread = 11;
+
+  for (let i = 0; i < 666; i++) {
+    const result = getRandomD1000Location(location, spread);
+
+    console.log("result > ", result);
+    expect(result >= 984 && result <= 999).toBe(true);
   }
 });

--- a/src/pages/hand-to-hand/index.jsx
+++ b/src/pages/hand-to-hand/index.jsx
@@ -146,7 +146,7 @@ export const Component = () => {
   );
 };
 
-const IndexPage = () => {
+const HandToHandPage = () => {
   return (
     <Layout>
       <Component />
@@ -154,4 +154,4 @@ const IndexPage = () => {
   );
 };
 
-export default IndexPage;
+export default HandToHandPage;

--- a/src/pages/shotguns/index.jsx
+++ b/src/pages/shotguns/index.jsx
@@ -1,10 +1,105 @@
-import React from "react";
+import React, { useState } from "react";
 import Layout from "../../components/layout";
+import { pelletSpreadTable, getRandomHitLocation } from "../../model/shotguns";
+import { form } from "./shotguns.module.css";
 
 export const Component = () => {
+  const [diceType, setDiceType] = useState(1000);
+  const [salm, setSalm] = useState(-12);
+  const [additionalHits, setAdditionalHits] = useState(1);
+  const [location, setLocation] = useState(0);
+  const [randomLocations, setRandomLocations] = useState(undefined);
+
+  const handleSubmit = () => {
+    let spread = pelletSpreadTable[salm];
+    if (diceType === 1000) {
+      spread = spread * 10;
+    }
+    const hits = [];
+
+    for (let i = 0; i < additionalHits; i++) {
+      hits.push(getRandomHitLocation(location, spread, diceType - 1));
+    }
+
+    setRandomLocations(hits);
+  };
+
   return (
     <div>
       <h1>Shotguns</h1>
+      <form className={form}>
+        <label>
+          <span>Initial Hit Location</span>
+          <input
+            type="number"
+            min="0"
+            max={diceType - 1}
+            name="initialLocation"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+          />
+        </label>
+        <label>
+          <span>SALM</span>
+          <select
+            value={salm}
+            onChange={(e) => {
+              setSalm(e.target.value);
+            }}
+          >
+            {Object.keys(pelletSpreadTable)
+              .sort((a, b) => a - b)
+              .map((k) => {
+                return (
+                  <option value={k} key={k}>
+                    {k}
+                  </option>
+                );
+              })}
+          </select>
+        </label>
+        <label>
+          <span>Additional Hits</span>
+          <input
+            type="number"
+            min="1"
+            max="25"
+            name="hitCount"
+            value={additionalHits}
+            onChange={(e) => setAdditionalHits(e.target.value)}
+          />
+        </label>
+        <label>
+          <span>Dice</span>
+          <select
+            value={diceType}
+            onChange={(e) => {
+              setDiceType(e.target.value);
+            }}
+          >
+            {[100, 1000].map((d) => {
+              return (
+                <option value={d} key={d}>
+                  {`d${d}`}
+                </option>
+              );
+            })}
+          </select>
+        </label>
+      </form>
+      <button type="button" onClick={handleSubmit}>
+        Random Locations
+      </button>
+      <button type="button" onClick={() => setRandomLocations(undefined)}>
+        Clear Locations
+      </button>
+      {randomLocations && (
+        <div>
+          {randomLocations.map((l, i) => {
+            return <span key={i}>{`${l},`}</span>;
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/shotguns/index.jsx
+++ b/src/pages/shotguns/index.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Layout from "../../components/layout";
+
+export const Component = () => {
+  return (
+    <div>
+      <h1>Shotguns</h1>
+    </div>
+  );
+};
+
+const ShotgunsPage = () => {
+  return (
+    <Layout>
+      <Component />
+    </Layout>
+  );
+};
+
+export default ShotgunsPage;

--- a/src/pages/shotguns/index.jsx
+++ b/src/pages/shotguns/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Layout from "../../components/layout";
 import { pelletSpreadTable, getRandomHitLocation } from "../../model/shotguns";
-import { form } from "./shotguns.module.css";
+import { form, locations } from "./shotguns.module.css";
 
 export const Component = () => {
   const [diceType, setDiceType] = useState(1000);
@@ -36,7 +36,7 @@ export const Component = () => {
             max={diceType - 1}
             name="initialLocation"
             value={location}
-            onChange={(e) => setLocation(e.target.value)}
+            onChange={(e) => setLocation(Number(e.target.value))}
           />
         </label>
         <label>
@@ -66,7 +66,7 @@ export const Component = () => {
             max="25"
             name="hitCount"
             value={additionalHits}
-            onChange={(e) => setAdditionalHits(e.target.value)}
+            onChange={(e) => setAdditionalHits(Number(e.target.value))}
           />
         </label>
         <label>
@@ -74,7 +74,7 @@ export const Component = () => {
           <select
             value={diceType}
             onChange={(e) => {
-              setDiceType(e.target.value);
+              setDiceType(Number(e.target.value));
             }}
           >
             {[100, 1000].map((d) => {
@@ -94,9 +94,9 @@ export const Component = () => {
         Clear Locations
       </button>
       {randomLocations && (
-        <div>
+        <div className={locations}>
           {randomLocations.map((l, i) => {
-            return <span key={i}>{`${l},`}</span>;
+            return <span key={i}>{l}</span>;
           })}
         </div>
       )}

--- a/src/pages/shotguns/shotguns.module.css
+++ b/src/pages/shotguns/shotguns.module.css
@@ -1,0 +1,14 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  width: fit-content;
+}
+
+.form > label {
+  display: flex;
+  justify-content: space-between;
+}
+
+.form > label > span {
+  margin-right: 1em;
+}

--- a/src/pages/shotguns/shotguns.module.css
+++ b/src/pages/shotguns/shotguns.module.css
@@ -7,8 +7,25 @@
 .form > label {
   display: flex;
   justify-content: space-between;
+  margin-bottom: 0.5em;
 }
 
 .form > label > span {
   margin-right: 1em;
+}
+
+.locations {
+  display: flex;
+  width: 15em;
+  flex-wrap: wrap;
+}
+
+.locations > span {
+  background-color: var(--usaf-light-grey);
+  border-radius: 5px;
+  padding: 2px;
+  width: 1.75em;
+  text-align: center;
+  margin-right: 0.5em;
+  margin-top: 1em;
 }

--- a/src/pages/shotguns/shotguns.test.js
+++ b/src/pages/shotguns/shotguns.test.js
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import React from "react";
+
+import Component from "./";
+
+import * as shotgunModel from "../../model/shotguns";
+
+test("it renders correct number of results", () => {
+  const { container } = render(<Component />);
+
+  const hitsInput = screen.getByLabelText("Additional Hits");
+  fireEvent.change(hitsInput, { target: { value: "11" } });
+
+  const randomLocations = screen.getByText("Random Locations");
+  fireEvent.click(randomLocations);
+
+  const locations = container.getElementsByClassName("locations")[0];
+
+  const results = within(locations).queryAllByText((value) => {
+    if (value === "") {
+      return false;
+    }
+
+    return typeof Number(value) === "number";
+  });
+  expect(results.length).toBe(11);
+});
+
+test("it adjusts HLS and upper limit for d1000 rolls", () => {
+  const spy = jest.spyOn(shotgunModel, "getRandomHitLocation");
+
+  const initLocation = 0;
+  const hlsBySalm = 2;
+  const upperLimit = 999;
+
+  render(<Component />);
+
+  const salmInput = screen.getByLabelText("SALM");
+  fireEvent.change(salmInput, { target: { value: "-10" } });
+
+  const randomLocations = screen.getByText("Random Locations");
+  fireEvent.click(randomLocations);
+
+  expect(spy).toHaveBeenCalledWith(initLocation, hlsBySalm * 10, upperLimit);
+});


### PR DESCRIPTION
Add tool to generate pseudo random hit locations based on initial hit location and shotgun SALM value

* Used rules in core rule book
* Made adjustment when rolling d1000 on Advanced Hit Locations as original rules where for d100 rolls on the standard core rules hit chart

#### Notes
Making effort to use React Testing Library as it has gone from `New Hotness` to standard.
I have written a lot of tests in Enzyme, some good, some bad - based on this and some other experiences with RTL, I find it a bit frustrating to work with outside of basic tests. I am not particularly interested in adding test id tags either which doesn't help. Maybe it'll get better as I learn more and become better familiarised - but just being able to test the expected number of random numbers rendered was annoying. The `within` method is nice - except it included the container as well as what was 'within' it, so the method name is somewhat misleading. I ended up not writing some tests because it wasn't worth the effort and replaced another with a jest spy. One could say it is unit tested, but the integration testing leaves a lot to be desired - which is weird because the champions of RTL are also in favour of moving away from unit tests to integration tests. Anyway self-absorbed moaning over.

<img width="507" alt="Screen Shot 2022-05-27 at 3 12 37 pm" src="https://user-images.githubusercontent.com/30450957/170859063-7366f171-89cd-4f7a-b294-b3b42405a9b0.png">

<img width="751" alt="Screen Shot 2022-05-29 at 9 29 56 am" src="https://user-images.githubusercontent.com/30450957/170859090-3061152f-68fb-40c5-add1-01b81323da04.png">

<img width="740" alt="Screen Shot 2022-05-29 at 10 02 51 am" src="https://user-images.githubusercontent.com/30450957/170859092-ae7123dc-e7d3-41d9-8c6e-30823c49b132.png">
